### PR TITLE
add appveyor configuration to use version of VS2019 with dotnet core 3 sdk support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,1 @@
+image: Visual Studio 2019


### PR DESCRIPTION
To potentially fix this issue:
https://github.com/ThreeMammals/Ocelot/pull/1025