### PR TITLE
Update obsoleted SetCollectionValidator methods

### DIFF
--- a/src/Ocelot/Configuration/Validator/FileConfigurationFluentValidator.cs
+++ b/src/Ocelot/Configuration/Validator/FileConfigurationFluentValidator.cs
@@ -21,8 +21,8 @@
                 .GetServices<ServiceDiscoveryFinderDelegate>()
                 .ToList();
 
-            RuleFor(configuration => configuration.ReRoutes)
-                .SetCollectionValidator(reRouteFluentValidator);
+            RuleForEach(configuration => configuration.ReRoutes)
+                .SetValidator(reRouteFluentValidator);
 
             RuleFor(configuration => configuration.GlobalConfiguration)
                 .SetValidator(fileGlobalConfigurationFluentValidator);

--- a/src/Ocelot/Configuration/Validator/ReRouteFluentValidator.cs
+++ b/src/Ocelot/Configuration/Validator/ReRouteFluentValidator.cs
@@ -80,8 +80,8 @@
 
             When(reRoute => string.IsNullOrEmpty(reRoute.ServiceName), () =>
             {
-                RuleFor(reRoute => reRoute.DownstreamHostAndPorts)
-                    .SetCollectionValidator(hostAndPortValidator);
+                RuleForEach(reRoute => reRoute.DownstreamHostAndPorts)
+                    .SetValidator(hostAndPortValidator);
             });
         }
 


### PR DESCRIPTION
Fixed build warning

```
Configuration\Validator\ReRouteFluentValidator.cs(83,17): warning CS0618: 'CollectionValidatorExtensions.SetCollectionValidator<T, TCollectionElement>(IRuleBuilder<T, IEnumerable<TCollectionElement>>, IValidator<TCollectionElement>)' is obsolete: 'SetCollectionValidator is deprecated. Please use RuleForEach(..).SetValidator(..) instead.
Configuration\Validator\FileConfigurationFluentValidator.cs(24,13): warning CS0618: 'CollectionValidatorExtensions.SetCollectionValidator<T, TCollectionElement>(IRuleBuilder<T, IEnumerable<TCollectionElement>>, IValidator<TCollectionElement>)' is obsolete: 'SetCollectionValidator is deprecated. Please use RuleForEach(..).SetValidator(..) instead.
```