### PR TITLE
Swap out OpenCover for Coverlet

### DIFF
--- a/src/Ocelot.Provider.Consul/PollingConsulServiceDiscoveryProvider.cs
+++ b/src/Ocelot.Provider.Consul/PollingConsulServiceDiscoveryProvider.cs
@@ -2,16 +2,17 @@
 {
     using Logging;
     using ServiceDiscovery.Providers;
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Values;
 
-    public class PollConsul : IServiceDiscoveryProvider
+    public sealed class PollConsul : IServiceDiscoveryProvider, IDisposable
     {
         private readonly IOcelotLogger _logger;
         private readonly IServiceDiscoveryProvider _consulServiceDiscoveryProvider;
-        private readonly Timer _timer;
+        private Timer _timer;
         private bool _polling;
         private List<Service> _services;
 
@@ -32,6 +33,12 @@
                 await Poll();
                 _polling = false;
             }, null, pollingInterval, pollingInterval);
+        }
+
+        public void Dispose()
+        {
+            _timer?.Dispose();
+            _timer = null;
         }
 
         public Task<List<Service>> Get()

--- a/test/Ocelot.UnitTests/Consul/PollingConsulServiceDiscoveryProviderTests.cs
+++ b/test/Ocelot.UnitTests/Consul/PollingConsulServiceDiscoveryProviderTests.cs
@@ -77,6 +77,8 @@
             });
 
             result.ShouldBeTrue();
+
+            _provider.Dispose();
         }
     }
 }

--- a/test/Ocelot.UnitTests/Consul/ProviderFactoryTests.cs
+++ b/test/Ocelot.UnitTests/Consul/ProviderFactoryTests.cs
@@ -49,7 +49,8 @@ namespace Ocelot.UnitTests.Consul
                 .Build();
 
             var provider = ConsulProviderFactory.Get(_provider, new ServiceProviderConfiguration("pollconsul", "", 1, "", "", stopsPollerFromPolling), reRoute);
-            provider.ShouldBeOfType<PollConsul>();
+            var pollProvider = provider as PollConsul;
+            pollProvider.ShouldNotBeNull();
         }
     }
 }

--- a/test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
+++ b/test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
@@ -89,5 +89,9 @@
 
   <ItemGroup>
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" />
+    <PackageReference Include="coverlet.collector" Version="1.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/test/Ocelot.UnitTests/UnitTests.runsettings
+++ b/test/Ocelot.UnitTests/UnitTests.runsettings
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>opencover</Format>
+          <SingleHit>false</SingleHit>
+          <UseSourceLink>true</UseSourceLink>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+  <!-- This is a workaround for an issue with Coverlet.Collector > 1.0.0 (see https://github.com/microsoft/vstest/issues/2205)-->
+  <InProcDataCollectionRunSettings>
+    <InProcDataCollectors>
+      <InProcDataCollector assemblyQualifiedName="Coverlet.Collector.DataCollection.CoverletInProcDataCollector, coverlet.collector, Version=1.1.0.0, Culture=neutral, PublicKeyToken=null"
+                     friendlyName="XPlat Code Coverage"
+                     enabled="True"
+                     codebase="coverlet.collector.dll" />
+    </InProcDataCollectors>
+  </InProcDataCollectionRunSettings>
+</RunSettings>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.25.0" />
+    <package id="Cake" version="0.35.0" />
 </packages>


### PR DESCRIPTION
As discussed in ThreeMammals/Ocelot#1025 it looks like OpenCover doesn't currently support .NET Core 3.0. I've therefore made some changes to the build script to use Coverlet instead, since it seems that it is the preferred tool moving forward and is integrated with the VSTest platform as well.

Some notes on these changes:
- After switching to Coverlet's In-Proc Data Collector I had test failures. This was caused by the PollingConsulServiceDiscoveryProvider (aka PollConsul) class that uses a Timer that wasn't being disposed properly, causing the test process to crash. I therefore implemented IDisposable on that class and made sure it is properly disposed within the tests.
- There's a known issue with Coverlet's Collector with versions higher than 1.0.0 (see microsoft/vstest#2205), so I put in the workaround within the UnitTests.runsettings file.
- As an added benefit of switching to Coverlet it seems that coverage can now be determined cross-platform as well, so I removed the check for running on Windows. I've tested these changes locally on my Mac and it works just fine. Curious to see how it will work in AppVeyor.