### PR TITLE
Downgrade coveralls.net to 0.7.0

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -3,7 +3,7 @@
 #addin nuget:?package=Cake.Json
 #addin nuget:?package=Newtonsoft.Json
 #tool "nuget:?package=ReportGenerator"
-#tool "nuget:?package=coveralls.net&version=1.0.0"
+#tool "nuget:?package=coveralls.net&version=0.7.0"
 #addin Cake.Coveralls&version=0.10.1
 
 // compile
@@ -130,7 +130,6 @@ Task("RunUnitTests")
 		DotNetCoreTest(unitTestAssemblies, testSettings);
 
 		var coverageSummaryFile = GetSubDirectories(artifactsForUnitTestsDir).First() + File("/coverage.opencover.xml");
-		Console.WriteLine(coverageSummaryFile);
 	
 		ReportGenerator(coverageSummaryFile, artifactsForUnitTestsDir);
 	

--- a/test/Ocelot.UnitTests/Consul/PollingConsulServiceDiscoveryProviderTests.cs
+++ b/test/Ocelot.UnitTests/Consul/PollingConsulServiceDiscoveryProviderTests.cs
@@ -15,7 +15,6 @@
     public class PollingConsulServiceDiscoveryProviderTests
     {
         private readonly int _delay;
-        private PollConsul _provider;
         private readonly List<Service> _services;
         private readonly Mock<IOcelotLoggerFactory> _factory;
         private readonly Mock<IOcelotLogger> _logger;
@@ -56,29 +55,28 @@
 
         private void WhenIGetTheServices(int expected)
         {
-            _provider = new PollConsul(_delay, _factory.Object, _consulServiceDiscoveryProvider.Object);
-
-            var result = Wait.WaitFor(3000).Until(() =>
+            using (var provider = new PollConsul(_delay, _factory.Object, _consulServiceDiscoveryProvider.Object))
             {
-                try
+                var result = Wait.WaitFor(3000).Until(() =>
                 {
-                    _result = _provider.Get().GetAwaiter().GetResult();
-                    if (_result.Count == expected)
+                    try
                     {
-                        return true;
+                        _result = provider.Get().GetAwaiter().GetResult();
+                        if (_result.Count == expected)
+                        {
+                            return true;
+                        }
+
+                        return false;
                     }
+                    catch (Exception)
+                    {
+                        return false;
+                    }
+                });
 
-                    return false;
-                }
-                catch (Exception)
-                {
-                    return false;
-                }
-            });
-
-            result.ShouldBeTrue();
-
-            _provider.Dispose();
+                result.ShouldBeTrue();
+            }
         }
     }
 }

--- a/test/Ocelot.UnitTests/Consul/ProviderFactoryTests.cs
+++ b/test/Ocelot.UnitTests/Consul/ProviderFactoryTests.cs
@@ -51,6 +51,7 @@ namespace Ocelot.UnitTests.Consul
             var provider = ConsulProviderFactory.Get(_provider, new ServiceProviderConfiguration("pollconsul", "", 1, "", "", stopsPollerFromPolling), reRoute);
             var pollProvider = provider as PollConsul;
             pollProvider.ShouldNotBeNull();
+            pollProvider.Dispose();
         }
     }
 }


### PR DESCRIPTION
I believe this will fix the build for AppVeyor at least. Looks like the Coveralls.NET cake plugin doesn't yet support coveralls.net 1.0.0, since that is now a .NET Core Global Tool.

I also fixed an issue I ran into locally where there was another unit test that used the PollConsul class, but didn't dispose of it properly.