### PR TITLE
Remove environment specific path separator

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -129,8 +129,7 @@ Task("RunUnitTests")
 		EnsureDirectoryExists(artifactsForUnitTestsDir);
 		DotNetCoreTest(unitTestAssemblies, testSettings);
 
-		var coverageSummaryFile = GetSubDirectories(artifactsForUnitTestsDir).First() + File("/coverage.opencover.xml");
-		Console.WriteLine(coverageSummaryFile);
+		var coverageSummaryFile = GetSubDirectories(artifactsForUnitTestsDir).First().CombineWithFilePath(File("coverage.opencover.xml"));
 	
 		ReportGenerator(coverageSummaryFile, artifactsForUnitTestsDir);
 	


### PR DESCRIPTION
Hopefully this will fix the Travis CI build since we were using an environment specific path separator which might break on other platforms. Not entirely sure that will fix the issue, but it's the best I can come up with given the error we see in the Travis build.