### PR TITLE
Fix startup issue with Consul

### DIFF
--- a/src/Ocelot.Provider.Consul/ConsulFileConfigurationRepository.cs
+++ b/src/Ocelot.Provider.Consul/ConsulFileConfigurationRepository.cs
@@ -28,10 +28,11 @@
             _cache = cache;
 
             var serviceDiscoveryProvider = fileConfiguration.Value.GlobalConfiguration.ServiceDiscoveryProvider;
+            _configurationKey = serviceDiscoveryProvider.ConfigurationKey ?? "InternalConfiguration";
+
             var config = new ConsulRegistryConfiguration(serviceDiscoveryProvider.Host,
                 serviceDiscoveryProvider.Port, _configurationKey, serviceDiscoveryProvider.Token);
 
-            _configurationKey = serviceDiscoveryProvider.ConfigurationKey ?? "InternalConfiguration";
             _consul = factory.Get(config);
         }
 

--- a/src/Ocelot.Provider.Consul/ConsulFileConfigurationRepository.cs
+++ b/src/Ocelot.Provider.Consul/ConsulFileConfigurationRepository.cs
@@ -4,6 +4,7 @@
     using Configuration.Repository;
     using global::Consul;
     using Logging;
+    using Microsoft.Extensions.Options;
     using Newtonsoft.Json;
     using Responses;
     using System;
@@ -18,30 +19,19 @@
         private readonly IOcelotLogger _logger;
 
         public ConsulFileConfigurationRepository(
+            IOptions<FileConfiguration> fileConfiguration,
             Cache.IOcelotCache<FileConfiguration> cache,
-            IInternalConfigurationRepository repo,
             IConsulClientFactory factory,
             IOcelotLoggerFactory loggerFactory)
         {
             _logger = loggerFactory.CreateLogger<ConsulFileConfigurationRepository>();
             _cache = cache;
 
-            var internalConfig = repo.Get();
+            var serviceDiscoveryProvider = fileConfiguration.Value.GlobalConfiguration.ServiceDiscoveryProvider;
+            var config = new ConsulRegistryConfiguration(serviceDiscoveryProvider.Host,
+                serviceDiscoveryProvider.Port, _configurationKey, serviceDiscoveryProvider.Token);
 
-            _configurationKey = "InternalConfiguration";
-
-            string token = null;
-
-            if (!internalConfig.IsError)
-            {
-                token = internalConfig.Data.ServiceProviderConfiguration.Token;
-                _configurationKey = !string.IsNullOrEmpty(internalConfig.Data.ServiceProviderConfiguration.ConfigurationKey) ?
-                    internalConfig.Data.ServiceProviderConfiguration.ConfigurationKey : _configurationKey;
-            }
-
-            var config = new ConsulRegistryConfiguration(internalConfig.Data.ServiceProviderConfiguration.Host,
-                internalConfig.Data.ServiceProviderConfiguration.Port, _configurationKey, token);
-
+            _configurationKey = serviceDiscoveryProvider.ConfigurationKey ?? "InternalConfiguration";
             _consul = factory.Get(config);
         }
 


### PR DESCRIPTION
As described in aspnet/AspNetCore#14585 IHostedService implementations are created earlier in the startup of an application with .NET Core 3.0. This caused an ordering issue within Ocelot where the `ConsulFileConfigurationRepository` was being created while the `IInternalConfiguration` wasn't set yet, causing a `NullReferenceException` in the constructor.

This PR changes the behaviour so that `ConsulFileConfigurationRepository` only depends on the statically known configuration at startup, rather than the configuration being read from Consul. This is a behavioural change, but I think it doesn't make much sense to support changing the ServiceDiscoveryProvider configuration from within the configured service discovery provider any way.